### PR TITLE
Fix ToC landmarks problems

### DIFF
--- a/src/epub/toc.xhtml
+++ b/src/epub/toc.xhtml
@@ -84,10 +84,13 @@
 					<a href="text/dedication.xhtml" epub:type="frontmatter z3998:non-fiction dedication">Dedication</a>
 				</li>
 				<li>
+					<a href="text/halftitle.xhtml" epub:type="bodymatter halftitlepage">Half Title</a>
+				</li>
+				<li>
 					<a href="text/the-coming-of-arthur.xhtml" epub:type="bodymatter z3998:fiction">Idylls of the King</a>
 				</li>
 				<li>
-					<a href="text/loi.xhtml" epub:type="bodymatter loi">List of Illustrations</a>
+					<a href="text/loi.xhtml" epub:type="backmatter loi">List of Illustrations</a>
 				</li>
 				<li>
 					<a href="text/colophon.xhtml" epub:type="backmatter colophon">Colophon</a>


### PR DESCRIPTION
LoI should be backmatter, and half title added. This now passes linting.